### PR TITLE
Added support for data-encoding, VTT files (and not just vtt) and SRT files with multiple blank lines

### DIFF
--- a/dist/source.es.js
+++ b/dist/source.es.js
@@ -77,6 +77,8 @@ class Cue {
  * @returns Cue
  */
 function toVttCue(srtCue) {
+    if (srtCue == '')
+        return [];
     const convertedCue = {
         number: parseInt(srtCue.match(/^\d+/g)[0]),
         timing: {
@@ -121,6 +123,8 @@ function hmsToSeconds(str) {
  * @returns Promise<string>
  */
 async function fetchTrack(src, encoding = 'utf-8') {
+    if (encoding == '')
+        encoding = "utf-8";
     return fetch(src).then(r => r.arrayBuffer()).then(r => new TextDecoder(encoding).decode(r));
 }
 
@@ -193,11 +197,11 @@ class Track {
         this.kind = track.kind;
         this.label = track.label;
         this.default = track.default;
-        this.needsTransform = !this.src.endsWith('.vtt');
+        this.needsTransform = !this.src.toLowerCase().endsWith('.vtt');
     }
     async parse() {
-        this.body = await fetchTrack(this.src);
-        this.cues = this.body.split(/\r?\n\r?\n/g).map(toVttCue);
+        this.body = await fetchTrack(this.src, thus.encoding);
+        this.cues = this.body.split(/\r?\n\r?\n/g).flatMap(toVttCue);
     }
 }
 


### PR DESCRIPTION
1. Added support for `data-encoding` (which was stated in readme but not actually used because the relevant parameter wasn't passed and utf-8 was always used)
1. Made the VTT detection case insensitive to also identify VTT files and not just vtt (as `endsWith` is case sensitive)
1. Added support for sequential blank SRT lines (e.g. script broke if for SRT files with 2 empty lines in their ending)